### PR TITLE
feat: add Twizzit events table

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -203,6 +203,67 @@ export type Database = {
         }
         Relationships: []
       }
+
+      twizzit_events: {
+        Row: {
+          id: string
+          twizzit_id: number
+          name: string
+          start_at: string
+          end_at: string
+          meeting_time: string | null
+          description: string | null
+          address: string | null
+          score: string | null
+          score_details: string | null
+          series: number | null
+          groups: Json | null
+          contacts: Json | null
+          resources: Json | null
+          raw: Json | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          twizzit_id: number
+          name: string
+          start_at: string
+          end_at: string
+          meeting_time?: string | null
+          description?: string | null
+          address?: string | null
+          score?: string | null
+          score_details?: string | null
+          series?: number | null
+          groups?: Json | null
+          contacts?: Json | null
+          resources?: Json | null
+          raw?: Json | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          twizzit_id?: number
+          name?: string
+          start_at?: string
+          end_at?: string
+          meeting_time?: string | null
+          description?: string | null
+          address?: string | null
+          score?: string | null
+          score_details?: string | null
+          series?: number | null
+          groups?: Json | null
+          contacts?: Json | null
+          resources?: Json | null
+          raw?: Json | null
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       user_roles: {
         Row: {
           created_at: string

--- a/supabase/migrations/20250820180000_ffd617b1-78e6-424f-9aa6-0b362fedd1a5.sql
+++ b/supabase/migrations/20250820180000_ffd617b1-78e6-424f-9aa6-0b362fedd1a5.sql
@@ -1,0 +1,23 @@
+-- Create twizzit_events table
+CREATE TABLE public.twizzit_events (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  twizzit_id bigint UNIQUE NOT NULL,
+  name text NOT NULL,
+  start_at timestamptz NOT NULL,
+  end_at timestamptz NOT NULL,
+  meeting_time time,
+  description text,
+  address text,
+  score text,
+  score_details text,
+  series bigint,
+  groups jsonb,
+  contacts jsonb,
+  resources jsonb,
+  raw jsonb,
+  created_at timestamptz DEFAULT now() NOT NULL,
+  updated_at timestamptz DEFAULT now() NOT NULL
+);
+
+-- Index for start_at to query upcoming events
+CREATE INDEX twizzit_events_start_at_idx ON public.twizzit_events (start_at);


### PR DESCRIPTION
## Summary
- add migration for `twizzit_events` table with start date index
- update Supabase generated types with `twizzit_events`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68c0859b6fe4832fbef3954ba9c8561c