### PR TITLE
feat: sync Twizzit events via edge function

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,21 @@ The project generates standard web app code that can be deployed anywhere:
 2. Deploy the `dist` folder to any static hosting service
 3. Configure environment variables for Supabase in your hosting environment
 
+### Twizzit Events Sync
+
+To keep the `twizzit_events` table up to date, deploy and schedule the `sync-twizzit-events` edge function:
+
+```bash
+supabase functions deploy sync-twizzit-events --no-verify-jwt
+supabase cron schedule twizzit-sync "0 2 * * *" sync-twizzit-events
+```
+
+Ensure the following secrets are configured in each environment:
+
+- `TWIZZIT_USERNAME`
+- `TWIZZIT_PASSWORD`
+- `TWIZZIT_ORG_ID`
+
 ## Contributing
 
 1. Fork the repository

--- a/supabase/functions/sync-twizzit-events/index.ts
+++ b/supabase/functions/sync-twizzit-events/index.ts
@@ -16,6 +16,16 @@ if (!supabaseUrl || !supabaseKey) {
 
 const supabase = createClient(supabaseUrl!, supabaseKey!);
 
+const twizzitUsername = Deno.env.get("TWIZZIT_USERNAME");
+const twizzitPassword = Deno.env.get("TWIZZIT_PASSWORD");
+const twizzitOrgId = Deno.env.get("TWIZZIT_ORG_ID");
+
+if (!twizzitUsername || !twizzitPassword || !twizzitOrgId) {
+  console.error("Missing Twizzit environment variables");
+}
+
+const TWIZZIT_API_BASE = "https://api.twizzit.com";
+
 interface TwizzitEvent {
   id: number;
   name: string;
@@ -39,8 +49,49 @@ serve(async (req) => {
   }
 
   try {
-    const body = await req.json();
-    const events: TwizzitEvent[] = body.events || [];
+    if (!twizzitUsername || !twizzitPassword || !twizzitOrgId) {
+      throw new Error("Missing Twizzit configuration");
+    }
+
+    const authRes = await fetch(`${TWIZZIT_API_BASE}/authenticate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        username: twizzitUsername,
+        password: twizzitPassword,
+      }),
+    });
+
+    if (!authRes.ok) {
+      throw new Error(`Authentication failed: ${authRes.status}`);
+    }
+
+    const { token } = (await authRes.json()) as { token: string };
+
+    if (!token) {
+      throw new Error("No authentication token returned");
+    }
+
+    const today = new Date();
+    const startDate = today.toISOString().split("T")[0];
+    const endDate = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .split("T")[0];
+
+    const eventsRes = await fetch(
+      `${TWIZZIT_API_BASE}/events?organization=${twizzitOrgId}&start=${startDate}&end=${endDate}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+
+    if (!eventsRes.ok) {
+      throw new Error(`Failed to fetch events: ${eventsRes.status}`);
+    }
+
+    const eventsData = await eventsRes.json();
+    const events: TwizzitEvent[] = Array.isArray(eventsData)
+      ? eventsData
+      : eventsData.events || [];
+
     const now = new Date().toISOString();
 
     const rows = events.map((event) => ({
@@ -73,12 +124,12 @@ serve(async (req) => {
 
     return new Response(
       JSON.stringify({ success: true, count: rows.length }),
-      { headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      { headers: { ...corsHeaders, "Content-Type": "application/json" } },
     );
   } catch (error) {
     return new Response(
       JSON.stringify({ error: (error as Error).message }),
-      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
     );
   }
 });


### PR DESCRIPTION
## Summary
- fetch Twizzit authentication and events using environment credentials
- upsert next-week events into `twizzit_events`
- document deployment and cron scheduling for Twizzit sync

## Testing
- `npm run lint` *(fails: react-hooks/exhaustive-deps, no-explicit-any, no-require-imports)*
- `npx eslint supabase/functions/sync-twizzit-events/index.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c08b136f5c832fb33046a5b275e581