### PR TITLE
docs: add Supabase CLI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ This project is built with modern web technologies:
 - Node.js 18+ or Bun
 - Git
 
+#### Supabase CLI
+Install the [Supabase CLI](https://supabase.com/docs/guides/cli) to manage Edge Functions and secrets.
+
+```bash
+npm i -g supabase
+```
+
+Authenticate your local environment before running deploy or cron commands:
+
+```bash
+supabase login
+```
+
 ### Quick Start
 
 1. **Clone the repository**
@@ -158,9 +171,10 @@ The project generates standard web app code that can be deployed anywhere:
 
 ### Twizzit Events Sync
 
-To keep the `twizzit_events` table up to date, deploy and schedule the `sync-twizzit-events` edge function:
+To keep the `twizzit_events` table up to date, deploy and schedule the `sync-twizzit-events` edge function. Make sure you're authenticated with Supabase CLI before running these commands:
 
 ```bash
+supabase login
 supabase functions deploy sync-twizzit-events --no-verify-jwt
 supabase cron schedule twizzit-sync "0 2 * * *" sync-twizzit-events
 ```


### PR DESCRIPTION
## Summary
- document how to install and authenticate with Supabase CLI
- remind to log in before deploying functions or scheduling cron jobs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e977b79c832f8f746f19a69cdc6a