### PR TITLE
docs: add custom Supabase project instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ npm run preview
 npm run lint
 ```
 
+## Custom Supabase Project
+
+To connect this codebase to your own Supabase project, update the client configuration.
+Edit `src/integrations/supabase/client.ts` and replace the `SUPABASE_URL` and `SUPABASE_PUBLISHABLE_KEY` constants with values from your Supabase project's dashboard.
+These values can be found under **Project Settings → API** in the Supabase dashboard.
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
## Summary
- document how to point the app at a different Supabase project

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ea507138832fbfab68dfc22aa0b0