### PR TITLE
docs: clarify clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ supabase login
 
 1. **Clone the repository**
    ```bash
-   git clone <YOUR_GIT_URL>
-   cd <YOUR_PROJECT_NAME>
+   git clone https://github.com/<owner>/dmon-hockey.git
+   cd dmon-hockey
    ```
+   Replace `<owner>` with the GitHub username or organization that owns the
+   repository. You can also substitute your fork's owner or URL for `<owner>`.
 
 2. **Install dependencies**
    ```bash


### PR DESCRIPTION
## Summary
- clarify repository cloning instructions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 4 errors, 16 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c2eb1356b8832f83a0ddb4a975401d