### PR TITLE
fix: resolve eslint errors

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -33,4 +33,5 @@ function Badge({ className, variant, ...props }: BadgeProps) {
   )
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export { Badge, badgeVariants }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -55,4 +55,5 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 )
 Button.displayName = "Button"
 
+// eslint-disable-next-line react-refresh/only-export-components
 export { Button, buttonVariants }

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,9 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
-
-const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
+const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -164,8 +164,10 @@ const FormMessage = React.forwardRef<
 })
 FormMessage.displayName = "FormMessage"
 
+// eslint-disable-next-line react-refresh/only-export-components
+export { useFormField }
+
 export {
-  useFormField,
   Form,
   FormItem,
   FormLabel,

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -115,8 +115,10 @@ const NavigationMenuIndicator = React.forwardRef<
 NavigationMenuIndicator.displayName =
   NavigationMenuPrimitive.Indicator.displayName
 
+// eslint-disable-next-line react-refresh/only-export-components
+export { navigationMenuTriggerStyle }
+
 export {
-  navigationMenuTriggerStyle,
   NavigationMenu,
   NavigationMenuList,
   NavigationMenuItem,

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -733,6 +733,9 @@ const SidebarMenuSubButton = React.forwardRef<
 })
 SidebarMenuSubButton.displayName = "SidebarMenuSubButton"
 
+// eslint-disable-next-line react-refresh/only-export-components
+export { useSidebar }
+
 export {
   Sidebar,
   SidebarContent,
@@ -757,5 +760,4 @@ export {
   SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
-  useSidebar,
 }

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -26,4 +26,5 @@ const Toaster = ({ ...props }: ToasterProps) => {
   )
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export { Toaster, toast }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -40,4 +40,5 @@ const Toggle = React.forwardRef<
 
 Toggle.displayName = TogglePrimitive.Root.displayName
 
+// eslint-disable-next-line react-refresh/only-export-components
 export { Toggle, toggleVariants }

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -20,6 +20,7 @@ const AuthContext = createContext<AuthContextType>({
   loading: true,
 });
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const useAuth = () => {
   const context = useContext(AuthContext);
   if (!context) {

--- a/src/pages/admin/AnnouncementForm.tsx
+++ b/src/pages/admin/AnnouncementForm.tsx
@@ -34,18 +34,13 @@ const AnnouncementForm = () => {
   const [featured, setFeatured] = useState(false);
   const [published, setPublished] = useState(false);
 
-  useEffect(() => {
-    if (isEditing && id) {
-      fetchAnnouncement(id);
-    }
-  }, [isEditing, id]);
-
-  const fetchAnnouncement = async (announcementId: string) => {
+  const fetchAnnouncement = useCallback(async () => {
+    if (!id) return;
     try {
       const { data, error } = await supabase
         .from('announcements')
         .select('*')
-        .eq('id', announcementId)
+        .eq('id', id)
         .single();
 
       if (error) throw error;
@@ -64,7 +59,13 @@ const AnnouncementForm = () => {
       });
       navigate('/admin/announcements');
     }
-  };
+  }, [id, navigate, toast]);
+
+  useEffect(() => {
+    if (isEditing) {
+      fetchAnnouncement();
+    }
+  }, [isEditing, fetchAnnouncement]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/pages/admin/Announcements.tsx
+++ b/src/pages/admin/Announcements.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { supabase } from '@/integrations/supabase/client';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -25,11 +25,7 @@ const Announcements = () => {
   const [announcements, setAnnouncements] = useState<Announcement[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    fetchAnnouncements();
-  }, []);
-
-  const fetchAnnouncements = async () => {
+  const fetchAnnouncements = useCallback(async () => {
     try {
       const { data, error } = await supabase
         .from('announcements')
@@ -48,7 +44,11 @@ const Announcements = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [toast]);
+
+  useEffect(() => {
+    fetchAnnouncements();
+  }, [fetchAnnouncements]);
 
   const deleteAnnouncement = async (id: string) => {
     if (!confirm('Are you sure you want to delete this announcement?')) return;

--- a/src/pages/admin/BoardMemberForm.tsx
+++ b/src/pages/admin/BoardMemberForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -38,18 +38,13 @@ const BoardMemberForm = () => {
     active: true,
   });
 
-  useEffect(() => {
-    if (isEditing && id) {
-      fetchBoardMember(id);
-    }
-  }, [isEditing, id]);
-
-  const fetchBoardMember = async (memberId: string) => {
+  const fetchBoardMember = useCallback(async () => {
+    if (!id) return;
     try {
       const { data, error } = await supabase
         .from('board_members')
         .select('*')
-        .eq('id', memberId)
+        .eq('id', id)
         .single();
 
       if (error) throw error;
@@ -73,7 +68,13 @@ const BoardMemberForm = () => {
       });
       navigate('/admin/board-members');
     }
-  };
+  }, [id, navigate, toast]);
+
+  useEffect(() => {
+    if (isEditing) {
+      fetchBoardMember();
+    }
+  }, [isEditing, fetchBoardMember]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/pages/admin/BoardMembers.tsx
+++ b/src/pages/admin/BoardMembers.tsx
@@ -1,5 +1,4 @@
-import { useState, useEffect } from 'react';
-import { useAuth } from '@/hooks/useAuth';
+import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -26,11 +25,7 @@ const BoardMembers = () => {
   const [boardMembers, setBoardMembers] = useState<BoardMember[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    fetchBoardMembers();
-  }, []);
-
-  const fetchBoardMembers = async () => {
+  const fetchBoardMembers = useCallback(async () => {
     try {
       const { data, error } = await supabase
         .from('board_members')
@@ -49,7 +44,11 @@ const BoardMembers = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [toast]);
+
+  useEffect(() => {
+    fetchBoardMembers();
+  }, [fetchBoardMembers]);
 
   const deleteBoardMember = async (id: string) => {
     if (!confirm('Are you sure you want to delete this board member?')) return;

--- a/src/pages/admin/SponsorForm.tsx
+++ b/src/pages/admin/SponsorForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -37,18 +37,13 @@ const SponsorForm = () => {
     active: true,
   });
 
-  useEffect(() => {
-    if (isEditing && id) {
-      fetchSponsor(id);
-    }
-  }, [isEditing, id]);
-
-  const fetchSponsor = async (sponsorId: string) => {
+  const fetchSponsor = useCallback(async () => {
+    if (!id) return;
     try {
       const { data, error } = await supabase
         .from('sponsors')
         .select('*')
-        .eq('id', sponsorId)
+        .eq('id', id)
         .single();
 
       if (error) throw error;
@@ -70,7 +65,13 @@ const SponsorForm = () => {
       });
       navigate('/admin/sponsors');
     }
-  };
+  }, [id, navigate, toast]);
+
+  useEffect(() => {
+    if (isEditing) {
+      fetchSponsor();
+    }
+  }, [isEditing, fetchSponsor]);
 
   const uploadLogo = async (): Promise<string | null> => {
     if (!logoFile) return formData.logo_path;

--- a/src/pages/admin/Sponsors.tsx
+++ b/src/pages/admin/Sponsors.tsx
@@ -1,5 +1,4 @@
-import { useState, useEffect } from 'react';
-import { useAuth } from '@/hooks/useAuth';
+import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -24,11 +23,7 @@ const Sponsors = () => {
   const [sponsors, setSponsors] = useState<Sponsor[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    fetchSponsors();
-  }, []);
-
-  const fetchSponsors = async () => {
+  const fetchSponsors = useCallback(async () => {
     try {
       const { data, error } = await supabase
         .from('sponsors')
@@ -47,7 +42,11 @@ const Sponsors = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [toast]);
+
+  useEffect(() => {
+    fetchSponsors();
+  }, [fetchSponsors]);
 
   const deleteSponsor = async (id: string) => {
     if (!confirm('Are you sure you want to delete this sponsor?')) return;

--- a/src/pages/admin/TeamForm.tsx
+++ b/src/pages/admin/TeamForm.tsx
@@ -1,5 +1,4 @@
-import { useState, useEffect } from 'react';
-import { useAuth } from '@/hooks/useAuth';
+import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -40,18 +39,13 @@ const TeamForm = () => {
     active: true,
   });
 
-  useEffect(() => {
-    if (isEditing && id) {
-      fetchTeam(id);
-    }
-  }, [isEditing, id]);
-
-  const fetchTeam = async (teamId: string) => {
+  const fetchTeam = useCallback(async () => {
+    if (!id) return;
     try {
       const { data, error } = await supabase
         .from('teams')
         .select('*')
-        .eq('id', teamId)
+        .eq('id', id)
         .single();
 
       if (error) throw error;
@@ -75,7 +69,13 @@ const TeamForm = () => {
       });
       navigate('/admin/teams');
     }
-  };
+  }, [id, navigate, toast]);
+
+  useEffect(() => {
+    if (isEditing) {
+      fetchTeam();
+    }
+  }, [isEditing, fetchTeam]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/pages/admin/Teams.tsx
+++ b/src/pages/admin/Teams.tsx
@@ -1,5 +1,4 @@
-import { useState, useEffect } from 'react';
-import { useAuth } from '@/hooks/useAuth';
+import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -24,11 +23,7 @@ const Teams = () => {
   const [teams, setTeams] = useState<Team[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    fetchTeams();
-  }, []);
-
-  const fetchTeams = async () => {
+  const fetchTeams = useCallback(async () => {
     try {
       const { data, error } = await supabase
         .from('teams')
@@ -47,7 +42,11 @@ const Teams = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [toast]);
+
+  useEffect(() => {
+    fetchTeams();
+  }, [fetchTeams]);
 
   const deleteTeam = async (id: string) => {
     if (!confirm('Are you sure you want to delete this team?')) return;

--- a/supabase/functions/fetch-instagram-posts/index.ts
+++ b/supabase/functions/fetch-instagram-posts/index.ts
@@ -43,13 +43,22 @@ serve(async (req) => {
       );
     }
 
-    const data = await response.json();
+    const data: {
+      data?: Array<{
+        id: string;
+        caption?: string;
+        media_url: string;
+        media_type: string;
+        timestamp: string;
+        permalink: string;
+      }>;
+    } = await response.json();
     console.log('Instagram API response:', data);
 
     // Transform the data to match our interface
-    const posts = data.data?.map((post: any) => ({
+    const posts = data.data?.map((post) => ({
       id: post.id,
-      caption: post.caption || '',
+      caption: post.caption ?? '',
       media_url: post.media_url,
       media_type: post.media_type,
       timestamp: post.timestamp,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -114,6 +115,6 @@ export default {
 				'accordion-up': 'accordion-up 0.2s ease-out'
 			}
 		}
-	},
-	plugins: [require("tailwindcss-animate")],
+        },
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- replace empty interfaces with direct types in CommandDialog and Textarea
- type Instagram API response to avoid `any`
- use ESM import for tailwindcss-animate plugin
- wrap admin fetch helpers with `useCallback` and proper dependencies
- disable `react-refresh/only-export-components` for shared utilities

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2ec2197ec832fab9d66cd9c26935d