### PR TITLE
test: add route loading checks

### DIFF
--- a/tests/gui/routes.spec.ts
+++ b/tests/gui/routes.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+
+const paths: string[] = [
+  '/',
+  '/auth',
+  '/events',
+  '/socials',
+  '/club/field',
+  '/club/teams',
+  '/club/board',
+  '/club/values',
+  '/club/news',
+  '/club/history',
+  '/club/sponsors',
+  '/club/privacy',
+  '/membership/info',
+  '/membership/register',
+  '/membership/insurance',
+  '/membership/contact',
+  '/shop',
+  '/sporting/training',
+  '/sporting/how-to-play',
+  '/sporting/rules',
+  '/sporting/stick-guide',
+  '/sporting/coaches-info',
+  '/admin',
+  '/admin/announcements',
+  '/admin/teams',
+  '/admin/sponsors',
+  '/admin/sponsors/new',
+  '/admin/sponsors/edit/1',
+  '/admin/board-members',
+  '/admin/board-members/new',
+  '/admin/board-members/edit/1',
+  '/admin/teams/new',
+  '/admin/teams/edit/1',
+  '/admin/announcements/new',
+  '/admin/announcements/edit/1',
+];
+
+for (const path of paths) {
+  test(`loads ${path}`, async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', err => errors.push(err.message));
+    await page.goto(path);
+    expect(errors).toHaveLength(0);
+  });
+}


### PR DESCRIPTION
## Summary
- add Playwright tests to ensure all routes load without client-side errors

## Testing
- `npm run lint`
- `npm run test:gui` *(fails: Host system is missing dependencies to run browsers; 35 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c3cd892a7c832fbdd9a3da584ed555