### PR TITLE
test: mock edge function calls in GUI tests

### DIFF
--- a/tests/gui/fixtures/edge-functions.ts
+++ b/tests/gui/fixtures/edge-functions.ts
@@ -1,0 +1,34 @@
+import { Page } from '@playwright/test';
+
+/**
+ * Mocks Supabase edge function calls for Playwright tests.
+ * Intercepts requests to the Instagram posts and Mapbox token edge functions.
+ */
+export async function mockEdgeFunctions(page: Page) {
+  await page.route('**/functions/v1/fetch-instagram-posts', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        posts: [
+          {
+            id: '1',
+            caption: 'mock post',
+            media_url: '/placeholder.svg',
+            media_type: 'IMAGE',
+            timestamp: '2024-01-01T00:00:00Z',
+            permalink: 'https://example.com/p/mock'
+          }
+        ]
+      })
+    });
+  });
+
+  await page.route('**/functions/v1/get-mapbox-token', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ token: 'mock-mapbox-token' })
+    });
+  });
+}

--- a/tests/gui/routes.spec.ts
+++ b/tests/gui/routes.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { mockEdgeFunctions } from './fixtures/edge-functions';
 
 const paths: string[] = [
   '/',
@@ -38,10 +39,23 @@ const paths: string[] = [
   '/admin/announcements/edit/1',
 ];
 
+const edgeFunctionPaths: string[] = ['/', '/socials', '/club/field'];
+// Add new edge-function pages to edgeFunctionPaths and mockedEdgeFunctionPaths.
+// Tests for pages present in edgeFunctionPaths but not in mockedEdgeFunctionPaths
+// will be skipped to avoid hitting real endpoints.
+const mockedEdgeFunctionPaths: string[] = ['/', '/socials', '/club/field'];
+const unmockedEdgeFunctionPaths = edgeFunctionPaths.filter(
+  (p) => !mockedEdgeFunctionPaths.includes(p)
+);
+
 for (const path of paths) {
-  test(`loads ${path}`, async ({ page }) => {
+  const run = unmockedEdgeFunctionPaths.includes(path) ? test.skip : test;
+  run(`loads ${path}`, async ({ page }) => {
+    if (mockedEdgeFunctionPaths.includes(path)) {
+      await mockEdgeFunctions(page);
+    }
     const errors: string[] = [];
-    page.on('pageerror', err => errors.push(err.message));
+    page.on('pageerror', (err) => errors.push(err.message));
     await page.goto(path);
     expect(errors).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary
- add Playwright helper to mock Supabase edge-function calls
- use helper in route tests and skip unmocked edge-function pages

## Testing
- `npm run lint`
- `npx playwright test` *(fails: missing browsers and host dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d013652c832f8043983bacdac0fa