### PR TITLE
chore: enforce read-only Supabase for tests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,4 @@
+VITE_SUPABASE_PROJECT_ID="rtvcsywkkcgakfzsuxgz"
+VITE_SUPABASE_URL="https://rtvcsywkkcgakfzsuxgz.supabase.co"
+VITE_SUPABASE_READONLY_KEY="READ_ONLY_SUPABASE_KEY"
+VITE_SUPABASE_ROLE="readonly"

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react-swc": "^3.11.0",
     "autoprefixer": "^10.4.21",
+    "dotenv": "^17.2.2",
     "eslint": "^9.32.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig } from '@playwright/test';
+import dotenv from 'dotenv';
+
+dotenv.config({ path: '.env.test' });
 
 export default defineConfig({
   testDir: 'tests/gui',

--- a/tests/gui/fixtures/read-only-supabase.ts
+++ b/tests/gui/fixtures/read-only-supabase.ts
@@ -1,0 +1,19 @@
+import { test as base, expect } from '@playwright/test';
+
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    const blocked: string[] = [];
+    await page.route('**/rest/v1/**', async (route) => {
+      if (route.request().method() !== 'GET') {
+        blocked.push(`${route.request().method()} ${route.request().url()}`);
+        await route.abort();
+      } else {
+        await route.continue();
+      }
+    });
+    await use(page);
+    expect(blocked, `Supabase write requests were blocked:\n${blocked.join('\n')}`).toHaveLength(0);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/tests/gui/routes.spec.ts
+++ b/tests/gui/routes.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/read-only-supabase';
 import { mockEdgeFunctions } from './fixtures/edge-functions';
 
 const paths: string[] = [


### PR DESCRIPTION
## Summary
- load test env with dotenv for Playwright
- block non-GET Supabase traffic in tests
- add read-only Supabase env vars
- restore bun.lockb to original state

## Testing
- `npm run test:gui` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d4051e44832fa86b12e21e2cf51b