### PR TITLE
docs: document GUI testing process

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,31 @@ supabase secrets set \
 Repeat for other environments (e.g., `--env dev`, `--env prod`) as needed.
 
 
+## GUI testing
+
+### Setup
+
+1. Start the development server in one terminal:
+   ```bash
+   npm run dev
+   ```
+2. In another terminal, run the Playwright suite:
+   ```bash
+   npm run test:gui
+   ```
+
+### Adding new route tests
+
+- Add the new path to the `paths` array in [`tests/gui/routes.spec.ts`](tests/gui/routes.spec.ts).
+- If the route triggers Supabase Edge Functions, also add it to `edgeFunctionPaths`.
+- Add the path to `mockedEdgeFunctionPaths` after implementing mocks so the test runs against stubbed data.
+
+### Edge functions and read-only policy
+
+- Edge function calls are stubbed via [`mockEdgeFunctions`](tests/gui/fixtures/edge-functions.ts) to avoid hitting real services.
+- Tests run with the [`read-only-supabase`](tests/gui/fixtures/read-only-supabase.ts) fixture, which blocks any non-GET Supabase requests and fails the test if a write is attempted.
+
+
 ## Contributing
 
 1. Fork the repository

--- a/tests/gui/fixtures/read-only-supabase.ts
+++ b/tests/gui/fixtures/read-only-supabase.ts
@@ -1,7 +1,9 @@
 import { test as base, expect } from '@playwright/test';
 
+/* eslint react-hooks/rules-of-hooks: off */
+
 export const test = base.extend({
-  page: async ({ page }, use) => {
+  page: async ({ page }, run) => {
     const blocked: string[] = [];
     await page.route('**/rest/v1/**', async (route) => {
       if (route.request().method() !== 'GET') {
@@ -11,7 +13,7 @@ export const test = base.extend({
         await route.continue();
       }
     });
-    await use(page);
+    await run(page);
     expect(blocked, `Supabase write requests were blocked:\n${blocked.join('\n')}`).toHaveLength(0);
   },
 });


### PR DESCRIPTION
## Summary
- document how to run and extend Playwright GUI tests
- silence React hooks lint error in read-only Supabase fixture

## Testing
- `npm run lint`
- `npm run test:gui` *(fails: 35 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c3dc87a8a4832fad6a57a82820cd6d