### PR TITLE
Add home page Playwright test

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test:gui": "playwright test",
-    "test:gui:headed": "playwright test --headed"
+    "test:gui:headed": "playwright test --headed",
+    "test:gui:home": "playwright test tests/gui/home.spec.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/tests/gui/home.spec.ts
+++ b/tests/gui/home.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from './fixtures/read-only-supabase';
+
+test('home page displays club name', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'D-mon Hockey Club' })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add home page Playwright test to check for club name
- add npm script to run only the home page test

## Testing
- `npm ci`
- `npm run build`
- `npm run test:gui:home` *(fails: browserType.launch: Executable doesn't exist; run `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68c3de5f5e34832f8578a070882f6069