### PR TITLE
Fix mobile sidebar closing logic

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -112,26 +112,26 @@ const navigation = [
 ];
 
 export function AppSidebar() {
-  const { open, setOpen } = useSidebar();
+  const { open, setOpen, openMobile, setOpenMobile } = useSidebar();
   const isMobile = useIsMobile();
   const location = useLocation();
   const currentPath = location.pathname;
 
   // Close sidebar on mobile when route changes
   useEffect(() => {
-    if (isMobile && open) {
+    if (isMobile && openMobile) {
       // Small delay to ensure navigation completes
       const timer = setTimeout(() => {
-        setOpen(false);
+        setOpenMobile(false);
       }, 100);
       return () => clearTimeout(timer);
     }
-  }, [currentPath, isMobile, open, setOpen]);
+  }, [currentPath, isMobile, openMobile, setOpenMobile]);
 
   // Handle mobile navigation click
   const handleMobileNavClick = () => {
-    if (isMobile && open) {
-      setOpen(false);
+    if (isMobile && openMobile) {
+      setOpenMobile(false);
     }
   };
 


### PR DESCRIPTION
## Summary
- destructure mobile sidebar state from `useSidebar`
- ensure mobile sidebar closes without affecting desktop state when navigating

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6a318d1e0832fa973a547e856e8c1