### PR TITLE
Enhance Twizzit team sync with contacts

### DIFF
--- a/supabase/functions/sync-twizzit-teams/index.ts
+++ b/supabase/functions/sync-twizzit-teams/index.ts
@@ -32,6 +32,9 @@ if (!twizzitUsername || !twizzitPassword || !twizzitOrgId) {
   console.error("Missing Twizzit environment variables");
 }
 const TWIZZIT_API_BASE = "https://app.twizzit.com/v2/api";
+const TRAINER_FUNCTION_ID = 242098;
+const COACH_FUNCTION_ID = 242093;
+
 serve(async (req)=>{
   const rid = crypto.randomUUID();
   const t0 = performance.now();
@@ -56,6 +59,22 @@ serve(async (req)=>{
     });
   }
   try {
+    const requestUrl = new URL(req.url);
+    const limitParam = requestUrl.searchParams.get("limit");
+    const limit = limitParam === null || limitParam === "" ? undefined : Number.parseInt(limitParam, 10);
+    if (limit !== undefined && (Number.isNaN(limit) || limit < 0)) {
+      return new Response(JSON.stringify({
+        success: false,
+        error: "Invalid limit parameter"
+      }), {
+        status: 400,
+        headers: {
+          ...corsHeaders,
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
     if (!twizzitUsername || !twizzitPassword || !twizzitOrgId) {
       throw new Error("Missing Twizzit configuration");
     }
@@ -102,7 +121,8 @@ serve(async (req)=>{
       throw new Error("No authentication token returned");
     }
     // FETCH TEAMS - Add pagination parameters to ensure we get all teams
-    const teamsUrl = `${TWIZZIT_API_BASE}/groups?organization-ids[]=${twizzitOrgId}&season-id=51270&group-type=1&limit=100&page=1`;
+    const teamLimit = limit !== undefined ? Math.min(Math.max(limit, 1), 100) : 100;
+    const teamsUrl = `${TWIZZIT_API_BASE}/groups?organization-ids[]=${twizzitOrgId}&season-id=51270&group-type=1&limit=${teamLimit}&page=1`;
     log("teams.request", {
       rid,
       url: teamsUrl
@@ -131,7 +151,10 @@ serve(async (req)=>{
       throw new Error(`Failed to fetch teams: ${teamsRes.status}`);
     }
     const teamsData = await teamsRes.json();
-    const teams = Array.isArray(teamsData) ? teamsData : teamsData.teams || [];
+    let teams = Array.isArray(teamsData) ? teamsData : teamsData.teams || [];
+    if (limit !== undefined) {
+      teams = teams.slice(0, limit);
+    }
     log("teams.parsed", {
       rid,
       count: teams.length,
@@ -143,45 +166,169 @@ serve(async (req)=>{
       return ageGroupMatch ? `U${ageGroupMatch[1]}` : null;
     };
     // MAP ROWS
-    const now = new Date().toISOString();
-    const rows = teams.map((team)=>({
+    const contactNameCache = new Map<number, string | null>();
+    const resolveContactName = async (contactId: number | null | undefined)=>{
+      if (!contactId) {
+        return null;
+      }
+      if (contactNameCache.has(contactId)) {
+        return contactNameCache.get(contactId) ?? null;
+      }
+      const contactsUrl = `${TWIZZIT_API_BASE}/contacts?organization-ids[]=${twizzitOrgId}&contact-ids[]=${contactId}`;
+      log("contacts.request", {
+        rid,
+        url: contactsUrl,
+        contactId
+      });
+      const contactsRes = await fetch(contactsUrl, {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      });
+      log("contacts.response", {
+        rid,
+        contactId,
+        status: contactsRes.status,
+        ok: contactsRes.ok
+      });
+      if (!contactsRes.ok) {
+        const preview = await contactsRes.text().catch(()=>"<unreadable>");
+        err("contacts.failed", {
+          rid,
+          contactId,
+          status: contactsRes.status,
+          bodyPreview: preview?.slice(0, 500)
+        });
+        contactNameCache.set(contactId, null);
+        return null;
+      }
+      const contactsData = await contactsRes.json();
+      const name = Array.isArray(contactsData) && contactsData.length > 0 ? contactsData[0]?.name ?? null : null;
+      contactNameCache.set(contactId, name ?? null);
+      return name ?? null;
+    };
+
+    const mappedRows = [];
+    for (const team of teams) {
+      const groupContactsUrl = `${TWIZZIT_API_BASE}/group-contacts?organization-ids[]=${twizzitOrgId}&group-ids[]=${team.id}`;
+      log("group_contacts.request", {
+        rid,
+        url: groupContactsUrl,
+        teamId: team.id
+      });
+      const groupContactsRes = await fetch(groupContactsUrl, {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      });
+      log("group_contacts.response", {
+        rid,
+        teamId: team.id,
+        status: groupContactsRes.status,
+        ok: groupContactsRes.ok
+      });
+      let groupContacts: Array<{ groupId: number; contactId: number; contactFunctionId: number }> = [];
+      if (groupContactsRes.ok) {
+        groupContacts = await groupContactsRes.json();
+      } else {
+        const preview = await groupContactsRes.text().catch(()=>"<unreadable>");
+        err("group_contacts.failed", {
+          rid,
+          teamId: team.id,
+          status: groupContactsRes.status,
+          bodyPreview: preview?.slice(0, 500)
+        });
+      }
+
+      const trainerContact = groupContacts.find((contact)=>contact.contactFunctionId === TRAINER_FUNCTION_ID);
+      const coachContact = groupContacts.find((contact)=>contact.contactFunctionId === COACH_FUNCTION_ID);
+
+      const [trainerName, coachName] = await Promise.all([
+        resolveContactName(trainerContact?.contactId),
+        resolveContactName(coachContact?.contactId)
+      ]);
+
+      const now = new Date().toISOString();
+      const row = {
         twizzit_id: team.id,
         name: team.name,
-        description: team['short-name'] ? `Short name: ${team['short-name']}` : null,
+        description: team["short-name"] ? `Short name: ${team["short-name"]}` : null,
         age_group: extractAgeGroup(team.name),
         season: team.season?.name || null,
         image_url: team.image,
         active: true,
         raw: team,
-        updated_at: now
-      }));
+        updated_at: now,
+        team_manager: trainerName,
+        coach: coachName
+      };
+
+      const { data: existingTeam, error: selectError } = await supabase.from("teams").select("id").eq("name", row.name).maybeSingle();
+      if (selectError) {
+        err("db.select.error", {
+          rid,
+          teamName: row.name,
+          code: selectError.code,
+          message: selectError.message,
+          details: selectError.details
+        });
+        throw selectError;
+      }
+
+      if (existingTeam) {
+        log("db.update.begin", {
+          rid,
+          teamName: row.name,
+          teamId: existingTeam.id
+        });
+        const { error: updateError } = await supabase.from("teams").update(row).eq("id", existingTeam.id);
+        if (updateError) {
+          err("db.update.error", {
+            rid,
+            teamName: row.name,
+            code: updateError.code,
+            message: updateError.message,
+            details: updateError.details
+          });
+          throw updateError;
+        }
+        log("db.update.success", {
+          rid,
+          teamName: row.name
+        });
+      } else {
+        log("db.insert.begin", {
+          rid,
+          teamName: row.name
+        });
+        const insertRow = {
+          ...row,
+          created_at: now
+        };
+        const { error: insertError } = await supabase.from("teams").insert(insertRow);
+        if (insertError) {
+          err("db.insert.error", {
+            rid,
+            teamName: row.name,
+            code: insertError.code,
+            message: insertError.message,
+            details: insertError.details
+          });
+          throw insertError;
+        }
+        log("db.insert.success", {
+          rid,
+          teamName: row.name
+        });
+      }
+
+      mappedRows.push(row);
+    }
+
     log("rows.mapped", {
       rid,
-      count: rows.length,
-      sample_names: rows.slice(0, 5).map((r)=>r.name)
-    });
-    // UPSERT
-    log("db.upsert.begin", {
-      rid,
-      table: "teams",
-      onConflict: "twizzit_id",
-      count: rows.length
-    });
-    const { error } = await supabase.from("teams").upsert(rows, {
-      onConflict: "twizzit_id"
-    });
-    if (error) {
-      err("db.upsert.error", {
-        rid,
-        code: error.code,
-        message: error.message,
-        details: error.details
-      });
-      throw error;
-    }
-    log("db.upsert.success", {
-      rid,
-      count: rows.length
+      count: mappedRows.length,
+      sample_names: mappedRows.slice(0, 5).map((r)=>r.name)
     });
     const t1 = performance.now();
     log("invoke.success", {
@@ -190,8 +337,8 @@ serve(async (req)=>{
     });
     return new Response(JSON.stringify({
       success: true,
-      count: rows.length,
-      message: `Successfully synced ${rows.length} teams`
+      count: mappedRows.length,
+      message: `Successfully synced ${mappedRows.length} teams`
     }), {
       headers: {
         ...corsHeaders,


### PR DESCRIPTION
## Summary
- add optional `limit` query parameter to the Twizzit team sync function and validate its input
- fetch group contacts per team to resolve trainer and coach names from Twizzit and persist them in Supabase
- replace the bulk upsert with targeted insert/update logic so existing teams are updated by name without clearing the table

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e568cee2f4832f9be5c5f6e4db1f9c